### PR TITLE
Set title to color to inherit

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -10,7 +10,7 @@ export default {
   actionTransformer: action => action,
   errorTransformer: error => error,
   colors: {
-    title: () => `#000000`,
+    title: () => `inherit`,
     prevState: () => `#9E9E9E`,
     action: () => `#03A9F4`,
     nextState: () => `#4CAF50`,


### PR DESCRIPTION
Since dev tools are just an HTML page, inherit the console's default color.
This fixes unreadable text in Chrome DevTools when the Dark theme is selected.