### PR TITLE
Log diff output directly instead of converting to string

### DIFF
--- a/src/diff.js
+++ b/src/diff.js
@@ -29,15 +29,15 @@ function render(diff) {
 
   switch (kind) {
     case `E`:
-      return `${path.join(`.`)} ${lhs} → ${rhs}`;
+      return [path.join(`.`), lhs, `→`, rhs];
     case `N`:
-      return `${path.join(`.`)} ${rhs}`;
+      return [path.join(`.`), rhs];
     case `D`:
-      return `${path.join(`.`)}`;
+      return [path.join(`.`)];
     case `A`:
       return [`${path.join(`.`)}[${index}]`, item];
     default:
-      return null;
+      return [];
   }
 }
 
@@ -59,7 +59,7 @@ export default function diffLogger(prevState, newState, logger, isCollapsed) {
       const { kind } = elem;
       const output = render(elem);
 
-      logger.log(`%c ${dictionary[kind].text}`, style(kind), output);
+      logger.log(`%c ${dictionary[kind].text}`, style(kind), ...output);
     });
   } else {
     logger.log(`—— no diff ——`);


### PR DESCRIPTION
I noticed when I enabled diffs that I was getting `[object Object]` in the diffs. I made this change so that instead of stringifying the output from `deep-diff`, the values are sent directly to `logger.log`.

I don't know about `console` implementations outside of Chrome, but Chrome's console works great at displaying the objects in a nice format for inspection.
