### PR TITLE
update default title formatter

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -36,7 +36,7 @@ function defaultTitleFormatter(options) {
     if (duration) {
       parts.push(`(in ${took.toFixed(2)} ms)`);
     }
-    returns parts.join(' ');
+    return parts.join(' ');
   }
 }
 

--- a/src/core.js
+++ b/src/core.js
@@ -27,8 +27,17 @@ function defaultTitleFormatter(options) {
     timestamp, duration,
   } = options;
 
-  return (action, time, took) =>
-    `action @ ${timestamp ? time : ``} ${action.type} ${duration ? `(in ${took.toFixed(2)} ms)` : ``}`;
+  return (action, time, took) => {
+    const parts = ['action'];
+    if (timestamp) {
+      parts.push(`@ ${time}`);
+    }
+    parts.push(action.type);
+    if (duration) {
+      parts.push(`(in ${took.toFixed(2)} ms)`);
+    }
+    returns parts.join(' ');
+  }
 }
 
 export function printBuffer(buffer, options) {

--- a/src/core.js
+++ b/src/core.js
@@ -28,7 +28,7 @@ function defaultTitleFormatter(options) {
   } = options;
 
   return (action, time, took) => {
-    const parts = ['action'];
+    const parts = [`action`];
     if (timestamp) {
       parts.push(`@ ${time}`);
     }
@@ -36,8 +36,8 @@ function defaultTitleFormatter(options) {
     if (duration) {
       parts.push(`(in ${took.toFixed(2)} ms)`);
     }
-    return parts.join(' ');
-  }
+    return parts.join(` `);
+  };
 }
 
 export function printBuffer(buffer, options) {


### PR DESCRIPTION
When disabling the timestamp you currently get the following

`action @  actionType`

The `@` is still present and there are two spaces between it and the action type (multiple spaces don't appear to render on github)