### PR TITLE
fix 'window is not defined' error in node

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,6 +1,6 @@
 export default {
   level: `log`,
-  logger: (this && this.console) || (window && window.console),
+  logger: (this && this.console) || (global.window && global.window.console),
   logErrors: true,
   collapsed: undefined,
   predicate: undefined,


### PR DESCRIPTION
This PR fixes a `ReferenceError: window is not defined` error which is thrown when running outside of a browser (e.g. node).

This broke in https://github.com/evgenyrodionov/redux-logger/pull/185/commits/b708f568ac2cd99b139c0865411da3cd855e4b03