### PR TITLE
Allow using non-string values for action.type

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -32,7 +32,7 @@ function defaultTitleFormatter(options) {
     if (timestamp) {
       parts.push(`@ ${time}`);
     }
-    parts.push(action.type);
+    parts.push(String(action.type));
     if (duration) {
       parts.push(`(in ${took.toFixed(2)} ms)`);
     }


### PR DESCRIPTION
Allow using non-string values for action.type, i.e. Symbol('RANDOM_ACTION_TYPE').