### PR TITLE
Feature: Add log entry persistence hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ createLogger(options?: Object) => LoggerMiddleware
   diff = false: Boolean, // Show diff between states.
   diffPredicate // Filter function for showing states diff.'
   persister // Function that takes an array of log objects, returns a Promise that is resolved when items are persisted
+  persistencePredicate // If specified, this function will be called after each action is processed to determine if it should be persisted.
   persistenceDelay // Minimum milliseconds between `persister` calls
 }
 ```
@@ -166,6 +167,11 @@ Filter states diff for certain cases.
 Function that takes an array of log objects, returns a Promise that is resolved when items are persisted
 
 *Default: `undefined`*
+
+#### ____persistencePredicate = (getState: Function, action: Object) => Boolean__
+If specified, this function will be called after each action is processed to determine if it should be persisted.
+
+*Default: `undefined` (always persists)*
 
 #### __persistenceDelay (Number)__
 Execution of `persister` will be postponed until after specified number of milliseconds have elapsed since the last time it was invoked.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Logger **must be** the last middleware in chain, otherwise it will log thunk and
 
 ## API
 
-`redux-logger` exposes single constructor function for creating logger middleware.  
+`redux-logger` exposes single constructor function for creating logger middleware.
 
 ```
 createLogger(options?: Object) => LoggerMiddleware
@@ -66,6 +66,8 @@ createLogger(options?: Object) => LoggerMiddleware
   titleFormatter, // Format the title used when logging actions.
   diff = false: Boolean, // Show diff between states.
   diffPredicate // Filter function for showing states diff.'
+  persister // Function that takes an array of log objects, returns a Promise that is resolved when items are persisted
+  persistenceDelay // Minimum milliseconds between `persister` calls
 }
 ```
 
@@ -159,6 +161,16 @@ Show states diff.
 Filter states diff for certain cases.
 
 *Default: `undefined`*
+
+#### __persister =  (logQueue: [Object]) => Promise__
+Function that takes an array of log objects, returns a Promise that is resolved when items are persisted
+
+*Default: `undefined`*
+
+#### __persistenceDelay (Number)__
+Execution of `persister` will be postponed until after specified number of milliseconds have elapsed since the last time it was invoked.
+
+*Default: `300`*
 
 ## Recipes
 ### Log only in development
@@ -275,6 +287,42 @@ export default createLogger({
   level,
   actionTransformer,
   logger
+});
+```
+
+### Persist logs to localStorage
+```javascript
+localStorage.clear(`actions`);
+
+const logPersister = (logQueue) => {
+  let array = JSON.parse(localStorage.getItem(`actions`)) || [];
+  array = array.concat(logQueue);
+  localStorage.setItem(`actions`, JSON.stringify(array));
+
+  return Promise.resolve();
+};
+
+const logger = createLogger({
+  persister: logPersister,
+});
+
+```
+
+### Persist logs via RESTful service
+```javascript
+import 'isomorphic-fetch';
+
+const logPersister = (logQueue) =>
+  fetch(ACTION_SERVICE_URL, {
+    method: `POST`,
+    headers: {
+      'Content-Type': `application/json`,
+    },
+    body: JSON.stringify(logQueue),
+  });
+
+const logger = createLogger({
+  persister: logPersister,
 });
 ```
 

--- a/example/src/index.js
+++ b/example/src/index.js
@@ -12,6 +12,16 @@ import Example from 'components/example';
 import reducers from 'reducers';
 import { AUTH_REMOVE_TOKEN, AUTH_SET_INFO, AUTH_SET_TOKEN } from 'constants/auth';
 
+localStorage.clear(`actions`);
+
+const logPersister = (logQueue) => {
+  let array = JSON.parse(localStorage.getItem(`actions`)) || [];
+  array = array.concat(logQueue);
+  localStorage.setItem(`actions`, JSON.stringify(array));
+
+  return Promise.resolve();
+};
+
 const logger = createLogger({
   predicate: (getState, action) => action.type !== AUTH_REMOVE_TOKEN, // log all actions except AUTH_REMOVE_TOKEN
   level: {
@@ -32,6 +42,8 @@ const logger = createLogger({
   },
   diff: true,
   diffPredicate: (getState, action) => action.type === AUTH_SET_TOKEN,
+  persister: logPersister,
+  persistenceDelay: 300,
 });
 
 const reducer = combineReducers(reducers);

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "webpack": "1.12.9"
   },
   "dependencies": {
-    "deep-diff": "0.3.4"
+    "deep-diff": "0.3.4",
+    "debounce": "^1.0.0"
   }
 }

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -19,6 +19,7 @@ export default {
   diff: false,
   diffPredicate: undefined,
   persister: undefined,
+  persistencePredicate: undefined,
   persistenceDelay: 300,
 
   // Deprecated options

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -18,6 +18,8 @@ export default {
   },
   diff: false,
   diffPredicate: undefined,
+  persister: undefined,
+  persistenceDelay: 300,
 
   // Deprecated options
   transformer: undefined,

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ import createDebouncedPersister from './persistence';
  * @param {function} options.actionTransformer - transform action before print
  * @param {function} options.errorTransformer - transform error before print
  * @param {function} options.persister - takes an array of log objects, returns a Promise that is resolved when items are persisted
+ * @param {function} options.persistencePredicate - determines if logs should be persisted
  * @param {number} options.persistenceDelay - debounce milliseconds
  * @returns {function} logger middleware
  */
@@ -35,6 +36,7 @@ function createLogger(options = {}) {
     predicate, logErrors,
     diffPredicate,
     persister,
+    persistencePredicate,
     persistenceDelay,
   } = loggerOptions;
 
@@ -87,7 +89,9 @@ function createLogger(options = {}) {
     const diff = loggerOptions.diff && typeof diffPredicate === `function` ? diffPredicate(getState, action) : loggerOptions.diff;
 
     if (persistBuffer) {
-      persistBuffer(asyncLogBuffer, { ...loggerOptions, diff });
+      if (typeof persistencePredicate !== `function` || persistencePredicate(getState, action)) {
+        persistBuffer(asyncLogBuffer, { ...loggerOptions, diff });
+      }
     }
 
     printBuffer(logBuffer, { ...loggerOptions, diff });

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -1,0 +1,18 @@
+import debounce from 'debounce';
+
+function persistBuffer(buffer, { persister }) {
+  persister(buffer)
+    .then(() => {
+      // clear the buffer - explicit side-effect
+      buffer.length = 0; // eslint-disable-line no-param-reassign
+    })
+    .catch(() => {
+      console.error(`failed to persist buffer`, buffer); // eslint-disable-line no-console
+    });
+}
+
+function createDebouncedPersister({ persistenceDelay = 300 }) {
+  return debounce(persistBuffer, persistenceDelay);
+}
+
+export default createDebouncedPersister;

--- a/src/persistence.js
+++ b/src/persistence.js
@@ -1,13 +1,18 @@
 import debounce from 'debounce';
 
-function persistBuffer(buffer, { persister }) {
-  persister(buffer)
+function persistBuffer(buffer, { persister, actionTransformer }) {
+  const transformedBuffer = buffer.map(({ action, ...logEntry }) => ({
+    ...logEntry,
+    action: actionTransformer(action),
+  }));
+
+  persister(transformedBuffer)
     .then(() => {
       // clear the buffer - explicit side-effect
       buffer.length = 0; // eslint-disable-line no-param-reassign
     })
     .catch(() => {
-      console.error(`failed to persist buffer`, buffer); // eslint-disable-line no-console
+      console.error(`failed to persist buffer`, transformedBuffer); // eslint-disable-line no-console
     });
 }
 


### PR DESCRIPTION
The `persister` callback is both optional and mechanism-agnostic - i.e. may work with localStorage, REST endpoints, Firebase, etc - so long as it returns a Promise.

The example has been updated to persist to localStorage, and the README updated to include recipes for REST and localStorage.

Add optional constructor arg, `persistencePredicate`, that, if specified, this function will be called after each action is processed to determine if it should be persisted.