### PR TITLE
Add trace for supported loggers

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -106,8 +106,8 @@ export function printBuffer(buffer, options) {
       else logger[nextStateLevel](`next state`, nextState);
     }
 
-    if (logger.trace) {
-      logger.groupCollapsed(`trace`);
+    if (logger.withTrace) {
+      logger.groupCollapsed(`TRACE`);
       logger.trace();
       logger.groupEnd();
     }

--- a/src/core.js
+++ b/src/core.js
@@ -106,6 +106,12 @@ export function printBuffer(buffer, options) {
       else logger[nextStateLevel](`next state`, nextState);
     }
 
+    if (logger.trace) {
+      logger.groupCollapsed(`trace`);
+      logger.trace();
+      logger.groupEnd();
+    }
+
     if (diff) {
       diffLogger(prevState, nextState, logger, isCollapsed);
     }


### PR DESCRIPTION
@evgenyrodionov, let me know if you'd like to see this done differently. We could also do a `try/catch` and print the stack trace, but this seems cleaner for most browsers (ie. Chrome). Here's a gif of how it looks:

![](https://cl.ly/2G252v24001R/Screen%20Recording%202017-02-28%20at%2004.59%20PM.gif)

We could also make this opt-in if you'd prefer. Let me know! 👍 

Closes #158 