### PR TITLE
`umd` and `es` targets instead of import source

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "3.0.6",
   "description": "Logger for Redux",
   "main": "dist/redux-logger.js",
+  "module": "dist/redux-logger.es.js",
+  "jsnext:main": "dist/redux-logger.es.js",
   "scripts": {
     "lint": "eslint src",
     "test": "npm run lint && npm run spec",
@@ -12,7 +14,8 @@
     "coverage:html": "nyc report --reporter=html && http-server -p 8077 ./coverage -o",
     "coverage:production": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "clean": "rimraf dist",
-    "build": "rollup -c",
+    "uglify": "uglifyjs dist/redux-logger.js -cm -o dist/redux-logger.js",
+    "build": "rollup -c && npm run uglify",
     "precommit": "npm test",
     "prepublish": "npm run clean && npm test && npm run build"
   },
@@ -38,8 +41,7 @@
     ]
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "repository": {
     "type": "git",
@@ -79,8 +81,8 @@
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-commonjs": "^8.0.2",
     "rollup-plugin-node-resolve": "^3.0.0",
-    "rollup-plugin-uglify": "^1.0.2",
-    "sinon": "^1.17.7"
+    "sinon": "^1.17.7",
+    "uglify-js": "^3.0.8"
   },
   "dependencies": {
     "deep-diff": "^0.3.5"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     ]
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "repository": {
     "type": "git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,14 +1,10 @@
 import babel from 'rollup-plugin-babel';
 import commonjs from 'rollup-plugin-commonjs';
 import nodeResolve from 'rollup-plugin-node-resolve';
-import uglify from 'rollup-plugin-uglify';
 
 export default {
   entry: 'src/index.js',
-  format: 'umd',
   exports: 'named',
-  moduleName: 'reduxLogger',
-  dest: 'dist/redux-logger.js',
   plugins: [
     babel({
       babelrc: false,
@@ -29,7 +25,17 @@ export default {
       jsnext: true,
       main: true,
       browser: true,
-    }),
-    uglify(),
+    })
   ],
+  targets: [
+    {
+        format: 'umd',
+        moduleName: 'reduxLogger',
+        dest: 'dist/redux-logger.js',
+    },
+    {
+      format: 'es',
+      dest: 'dist/redux-logger.es.js'
+    }
+  ]
 };


### PR DESCRIPTION
That should close #233.

But needs testing to prevent #229 and #231 to happen again.