### PR TITLE
Update comment to match implementation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ const store = createStore(
   applyMiddleware(logger)
 )
 // Or you can create your own logger with custom options http://bit.ly/redux-logger-options
-import createLogger from 'redux-logger'
+import { createLogger } from 'redux-logger'
 const logger = createLogger({
   // ...options
 });


### PR DESCRIPTION
Update comment to match what told in deprecation warnin 
`Since 3.0.0 redux-logger exports by default logger with default settings.`