### PR TITLE
Extended diff option to allow for a custom differ function

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Note: logger **must be** the last middleware in chain, otherwise it will log thu
   logger = console: LoggerObject, // implementation of the `console` API.
   logErrors = true: Boolean, // should the logger catch, log, and re-throw errors?
 
-  diff = false: Boolean, // (alpha) show diff between states?
+  diff = false: Boolean | customDiffer, // (alpha) show diff between states?
   diffPredicate // (alpha) filter function for showing states diff, similar to `predicate`
 }
 ```
@@ -159,8 +159,9 @@ Format the title used for each action.
 
 *Default: prints something like `action @ ${time} ${action.type} (in ${took.toFixed(2)} ms)`*
 
-#### __diff (Boolean)__
-Show states diff.
+#### __diff = (prevState: Object, newState: Object) => diff__
+Show states diff. Takes a boolean or optionally a custom differ to use instead of the default
+[`deep-diff`](https://github.com/flitbit/diff).
 
 *Default: `false`*
 

--- a/spec/diff.spec.js
+++ b/spec/diff.spec.js
@@ -1,5 +1,6 @@
 import sinon from 'sinon';
 import { expect } from 'chai';
+import differ from 'deep-diff';
 import { style, render, default as diffLogger } from '../src/diff';
 
 context('Diff', () => {
@@ -110,6 +111,17 @@ context('Diff', () => {
       diffLogger({name: 'kirk'}, {name: 'picard'}, logger, false);
 
       expect(logger.log.calledWithExactly('%c CHANGED:', 'color: #2196F3; font-weight: bold', 'name', 'kirk', '→', 'picard')).to.be.true;
+    });
+
+    it('should use a custom differ if provided', () => {
+      const callback = sinon.spy();
+      const customDiffer = (prevState, newState) => {
+        callback();
+        return differ(prevState, newState);
+      };
+      diffLogger({name: 'kirk'}, {name: 'picard'}, logger, false, customDiffer);
+
+      expect(callback.called).to.be.true;
     });
   });
 });

--- a/src/core.js
+++ b/src/core.js
@@ -46,6 +46,7 @@ function printBuffer(buffer, options) {
     level,
     diff,
   } = options;
+  const customDiffer = typeof diff === 'function' ? diff : undefined;
 
   const isUsingDefaultFormatter = typeof options.titleFormatter === 'undefined';
 
@@ -126,7 +127,7 @@ function printBuffer(buffer, options) {
     }
 
     if (diff) {
-      diffLogger(prevState, nextState, logger, isCollapsed);
+      diffLogger(prevState, nextState, logger, isCollapsed, customDiffer);
     }
 
     try {

--- a/src/diff.js
+++ b/src/diff.js
@@ -41,8 +41,8 @@ export function render(diff) {
   }
 }
 
-export default function diffLogger(prevState, newState, logger, isCollapsed) {
-  const diff = differ(prevState, newState);
+export default function diffLogger(prevState, newState, logger, isCollapsed, customDiffer) {
+  const diff = (customDiffer || differ)(prevState, newState);
 
   try {
     if (isCollapsed) {


### PR DESCRIPTION
I use Immutable.js alongside an [Immutable.js Object Formatter Chrome Extension](https://github.com/mattzeunert/immutable-object-formatter-extension), and it would be great to be able to use a custom differ instead of needing to convert everything via the `stateTransformer` option.