### PR TITLE
Add module, jsnext:main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "3.0.6",
   "description": "Logger for Redux",
   "main": "dist/redux-logger.js",
+  "module": "src/index.js",
+  "jsnext:main": "src/index.js",
   "scripts": {
     "lint": "eslint src",
     "test": "npm run lint && npm run spec",


### PR DESCRIPTION
Hey. I'm using your excellent logger in a package which I build using rollup. I grab the ES6 sources from various node_modules and then bundle everything together in a single JS file which I serve up.

In order for rollup to do its thing properly, it needs an idea of where the ES6 sources live, which it gets from this value in your `package.json` file. So, if you'd like, here's that 2-line change to make it happen.

[Here's a bit of background](https://github.com/rollup/rollup/wiki/pkg.module) on the `pkg.module` property.

If you want to merge it back into the main project that would be nice, then I don't have to maintain my own fork. 😄 Thanks!