### PR TITLE
fix: added babel transform-object-assign to fix IE support

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "babel-core": "^6.24.0",
     "babel-plugin-external-helpers": "^6.22.0",
     "babel-plugin-transform-inline-environment-variables": "6.8.0",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-preset-es2015": "^6.24.0",
     "chai": "3.5.0",
     "codecov": "1.0.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -20,7 +20,7 @@ export default {
           },
         ],
       ],
-      plugins: ['external-helpers'],
+      plugins: ['external-helpers', 'transform-object-assign'],
     }),
     commonjs({
       include: 'node_modules/**',

--- a/src/core.js
+++ b/src/core.js
@@ -126,7 +126,7 @@ function printBuffer(buffer, options) {
     }
 
     if (logger.withTrace) {
-      logger.groupCollapsed(`TRACE`);
+      logger.groupCollapsed('TRACE');
       logger.trace();
       logger.groupEnd();
     }


### PR DESCRIPTION
Using native Object.assign was breaking IE support, so I pulled in `babel-plugin-transform-object-assign` to add in a polyfill when necessary.

Also the linter was complaining about the quotes around `TRACE` so I fixed that too.