### PR TITLE
Fix #264: Add support of styling custom `titleFormatter`

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -126,7 +126,7 @@ function printBuffer(buffer, options) {
     }
 
     if (logger.withTrace) {
-      logger.groupCollapsed(`TRACE`);
+      logger.groupCollapsed('TRACE');
       logger.trace();
       logger.groupEnd();
     }

--- a/src/core.js
+++ b/src/core.js
@@ -36,6 +36,10 @@ function defaultTitleFormatter(options) {
   };
 }
 
+function getTitle(title) {
+  return Object.prototype.toString.call(title) === '[object Array]' ? title : [title];
+}
+
 function printBuffer(buffer, options) {
   const {
     logger,
@@ -78,11 +82,11 @@ function printBuffer(buffer, options) {
       if (isCollapsed) {
         if (colors.title && isUsingDefaultFormatter) {
           logger.groupCollapsed(`%c ${title}`, ...headerCSS);
-        } else logger.groupCollapsed(title);
+        } else logger.groupCollapsed(...getTitle(title));
       } else if (colors.title && isUsingDefaultFormatter) {
         logger.group(`%c ${title}`, ...headerCSS);
       } else {
-        logger.group(title);
+        logger.group(...getTitle(title));
       }
     } catch (e) {
       logger.log(title);


### PR DESCRIPTION
Right now, there's no way to style console output with css when using custom `titleFormatter`.
This PR adds ability to return `Array` from `titleFormatter` that will be spread when passed to logger.
Eg. support this:
```js
createLogger({
  titleFormatter (action, time, took) {
    return [
      `%caction %c${action.type} %c@ ${time} %c(in ${took.toFixed(2)})`,
      'color: gray; font-weight: lighter;',
      'color: red;',
      'color: blue; font-weight: lighter;',
      'color: green; font-weight: lighter;'
    ];
  }
});
```