### PR TITLE
pin deep-diff version

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
     "sinon": "^1.17.7"
   },
   "dependencies": {
-    "deep-diff": "^0.3.5"
+    "deep-diff": "0.3.5"
   }
 }

--- a/src/core.js
+++ b/src/core.js
@@ -126,7 +126,7 @@ function printBuffer(buffer, options) {
     }
 
     if (logger.withTrace) {
-      logger.groupCollapsed(`TRACE`);
+      logger.groupCollapsed('TRACE');
       logger.trace();
       logger.groupEnd();
     }


### PR DESCRIPTION
deep-diff@0.3.8 was causing some unexpected errors and page reloads.
related to: https://github.com/evgenyrodionov/redux-logger/issues/273