### PR TITLE
Truncate colors if not supported

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -126,7 +126,7 @@ function printBuffer(buffer, options) {
     }
 
     if (logger.withTrace) {
-      logger.groupCollapsed(`TRACE`);
+      logger.groupCollapsed('TRACE');
       logger.trace();
       logger.groupEnd();
     }

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,6 +1,8 @@
+import * as logger from './logger';
+
 export default {
   level: 'log',
-  logger: console,
+  logger: console ? logger : undefined,
   logErrors: true,
   collapsed: undefined,
   predicate: undefined,

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,65 @@
+/*
+ * Browser support detection heavily borrowed from:
+ * https://github.com/evgenyrodionov/redux-logger/issues/170#issuecomment-240717892
+ */
+
+const isNode = typeof exports === 'object' && typeof module !== 'undefined';
+
+const browser = {
+  isNode,
+  isFirefox: !isNode && /firefox/i.test(navigator.userAgent),
+  isEdge: !isNode && /\bEdge\b/.test(navigator.userAgent),
+  isIE: !isNode && !!document.documentMode,
+  isChrome: !isNode && !!window.chrome,
+  isSafari: !isNode && !!window.safari,
+};
+
+const support = {
+  consoleStyles: !(isNode || browser.isIE || browser.isEdge),
+  consoleGroupStyles: browser.isChrome || browser.isSafari,
+};
+
+/**
+ * Proxies all console calls; if we don't have colors will strip out colors and
+ * next param(s) that define color information.
+ * @param {boolean} hasSupport whether we have color support
+ * @param {*[]} args arguments passed to console method
+ * @returns {*[]} array of (potentially truncated) arguments to pass back to console method
+ */
+function truncateColorArguments(hasSupport, ...args) {
+  if (hasSupport) { return args; }
+
+  const hasColorString = /%c/gi;
+
+  return args.reduce((memo, item, index, array) => {
+    // if {index} is a string and include %c, remove %c from the string.
+    // also remove any subsequent params (this would be color information)
+    if (typeof item === 'string' && hasColorString.test(item)) {
+      array.splice(index + 1, item.split(hasColorString).length - 1);
+      memo.push(item.replace(hasColorString, ''));
+    } else {
+      memo.push(item);
+    }
+    return memo;
+  }, []);
+}
+
+export function log(...args) {
+  console.log(...truncateColorArguments(support.consoleStyles, ...args));
+}
+
+export function group(...args) {
+  console.group(...truncateColorArguments(support.consoleGroupStyles, ...args));
+}
+
+export function groupCollapsed(...args) {
+  console.groupCollapsed(...truncateColorArguments(support.consoleGroupStyles, ...args));
+}
+
+export function groupEnd() {
+  try {
+    console.groupEnd();
+  } catch (e) {
+    log('—— log end ——');
+  }
+}


### PR DESCRIPTION
This is a rehash of #203 but with different logic - 203 won't work any more due to some assumptions that the log methods were only called with max 2 parameters. This uses a lot of the same browser detection logic, with the addition of node - but has a totally different method.

In short:

- figure out browser support ahead of time.  I've got node as not supporting colors (it does, but one would need to use ansi escape sequences which aren't really compatible with html color codes)

- proxy each of the used `console` methods and pass arguments to `truncateColorArguments` - 

- if colors are supported, return arguments unchanged, 

- if colors aren't supported, look for any `%c` in string arguments and if found remove the number of %c found in the string - this removes the formatting information.

Also, fixed the CI build... it seems that someone left backticks in `./src/core.js` and eslint was complaining.