### PR TITLE
fix lint issue and add lint on pre-commit/build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "coverage:production": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "clean": "rimraf dist",
     "build": "rollup -c",
-    "precommit": "npm test",
-    "prepublish": "npm run clean && npm test && npm run build"
+    "precommit": "npm test && npm run lint",
+    "prepublish": "npm run clean && npm test && npm run lint && npm run build"
   },
   "eslintConfig": {
     "extends": "airbnb",

--- a/src/core.js
+++ b/src/core.js
@@ -126,7 +126,7 @@ function printBuffer(buffer, options) {
     }
 
     if (logger.withTrace) {
-      logger.groupCollapsed(`TRACE`);
+      logger.groupCollapsed('TRACE');
       logger.trace();
       logger.groupEnd();
     }


### PR DESCRIPTION
When I pulled the latest code and ran `yarn`. It failed linting
- Fixed the issue
- Added `npm run lint` to `precommit` and `prepublish` scripts to prevent this from occurring in the future