### PR TITLE
check both the logger for withTrace and the options

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -45,6 +45,7 @@ function printBuffer(buffer, options) {
     colors,
     level,
     diff,
+    withTrace,
   } = options;
 
   const isUsingDefaultFormatter = typeof options.titleFormatter === 'undefined';
@@ -125,7 +126,7 @@ function printBuffer(buffer, options) {
       } else logger[nextStateLevel]('next state', nextState);
     }
 
-    if (logger.withTrace) {
+    if (withTrace && logger.trace) {
       logger.groupCollapsed('TRACE');
       logger.trace();
       logger.groupEnd();

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -18,6 +18,7 @@ export default {
   },
   diff: false,
   diffPredicate: undefined,
+  withTrace: false,
 
   // Deprecated options
   transformer: undefined,


### PR DESCRIPTION
There was an issue with: https://github.com/evgenyrodionov/redux-logger/pull/205

In the PR feedback it was recommended to make a `withTrace` option for the config, but instead it was used to check the logger object.

What we want to happen is to have a `withTrace` option checked off the config as well as a `trace` property checked off of the logger object to make sure it supports trace.